### PR TITLE
Render board

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -28,12 +28,12 @@ class Board
         end
         #Test for overlap
         if horizontal
-            0.upto(ship.length) do |i|
+            0.upto(ship.length - 1) do |i|
                 at = (coord[0] + (coord[1].to_i + i).to_s).to_sym
                 return false if !(@cells[at].empty?)
             end
         else
-            0.upto(ship.length) do |i|
+            0.upto(ship.length - 1) do |i|
                 at = ((coord[0].ord + i).chr + coord[1]).to_sym
                 return false if !(@cells[at].empty?)
             end
@@ -41,12 +41,12 @@ class Board
         #If tests passed, add ship
         @ships << ship
         if horizontal
-            0.upto(ship.length) do |i|
+            0.upto(ship.length - 1) do |i|
                 at = (coord[0] + (coord[1].to_i + i).to_s).to_sym
                 @cells[at].place(ship)
             end
         else
-            0.upto(ship.length) do |i|
+            0.upto(ship.length - 1) do |i|
                 at = ((coord[0].ord + i).chr + coord[1]).to_sym
                 @cells[at].place(ship)
             end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -1,7 +1,7 @@
 require './lib/cell'
 
 class Board
-    attr_reader :cells, :ships
+    attr_reader :cells, :ships, :size
     def initialize(size = 10)
         @cells = {}
         ('A'..(64+size).chr).each do |x| #As in x coord of graph

--- a/lib/render.rb
+++ b/lib/render.rb
@@ -1,0 +1,9 @@
+require './lib/board'
+
+class Render
+  attr_reader :board
+  
+  def initialize(board)
+    @board = board
+  end
+end

--- a/lib/render.rb
+++ b/lib/render.rb
@@ -10,6 +10,8 @@ class Render
     @board.size.times do |i|
       render_return += subsequent_row(i)
     end
+
+    render_return
   end
 
   def first_row

--- a/lib/render.rb
+++ b/lib/render.rb
@@ -1,9 +1,8 @@
 require './lib/board'
 
 class Render
-  attr_reader :board
-  
-  def initialize(board)
-    @board = board
+
+  def render(board)
+
   end
 end

--- a/lib/render.rb
+++ b/lib/render.rb
@@ -3,6 +3,17 @@ require './lib/board'
 class Render
 
   def render(board)
+    first_row(board)
+  end
 
+  def first_row(board)
+    size = board.size
+    first_row_return = " "
+
+    ('1'..size.to_s).each do |number|
+      first_row_return += " " + number
+    end
+
+    first_row_return += " \n"
   end
 end

--- a/lib/render.rb
+++ b/lib/render.rb
@@ -2,8 +2,9 @@ require './lib/board'
 
 class Render
 
-  def render(board)
+  def render(board, reveal = false)
     @board = board
+    @reveal = reveal
     render_return = first_row
 
     @board.size.times do |i|
@@ -24,7 +25,15 @@ class Render
 
   def subsequent_row(i)
     row_counter = i + 1 # starts at one
-    row_render = (64 + row_counter).chr
-    row_render += " . . . . \n" # HARD CODED
+    letter = (64 + row_counter).chr
+    row_render = letter
+
+    @board.size.times do |i|
+      number = (i + 1).to_s
+      cell = (letter + number).to_sym
+      row_render += " " + @board.cells[cell].render(@reveal) # TO DO: Board has a new method to get rid of .cells from this line -- update accordingly after merging
+    end
+
+    row_render += " \n"
   end
 end

--- a/lib/render.rb
+++ b/lib/render.rb
@@ -3,11 +3,16 @@ require './lib/board'
 class Render
 
   def render(board)
-    first_row(board)
+    @board = board
+    render_return = first_row
+
+    @board.size.times do |i|
+      render_return += subsequent_row(i)
+    end
   end
 
-  def first_row(board)
-    size = board.size
+  def first_row
+    size = @board.size
     first_row_return = " "
 
     ('1'..size.to_s).each do |number|
@@ -15,5 +20,11 @@ class Render
     end
 
     first_row_return += " \n"
+  end
+
+  def subsequent_row(i)
+    row_counter = i + 1 # starts at one
+    row_render = (64 + row_counter).chr
+    row_render += " . . . . \n" # HARD CODED
   end
 end

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -49,7 +49,7 @@ class BoardTest < Minitest::Test
         testShip = Ship.new("test", 5)
         assert testBoard.place(testShip, 'B2', true)
         assert_equal [testShip], testBoard.ships
-        0.upto(5) {|i| refute testBoard.cells[('B' + (2 + i).to_s).to_sym].empty?}
+        0.upto(4) {|i| refute testBoard.cells[('B' + (2 + i).to_s).to_sym].empty?}
     end
 
     def test_ship_placement_out_bounds

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -1,0 +1,19 @@
+require 'minitest/autorun'
+require 'minitest/pride'
+require './lib/render'
+
+class RenderTest < Minitest::Test
+  def test_it_exists
+    board = Board.new
+    render = Render.new(board)
+
+    assert_instance_of Render, render
+  end
+
+  def test_it_has_a_board
+    board = Board.new
+    render = Render.new(board)
+
+    assert_equal board, render.board
+  end
+end

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -77,6 +77,59 @@ class RenderTest < Minitest::Test
     assert_equal "D . . . . \n", render.subsequent_row(3)
   end
 
+  def test_subsequent_renders_hit_ships
+    board = Board.new(4)
+    render = Render.new
+    sub = Ship.new("Sub", 2)
+
+    board.place(sub, "A1", true)
+    # ^ places sub in A1 horizontally -- A1 and A2
+    board.cells[:A1].fire_upon
+
+    render.render(board, true)
+
+    assert_equal "A H S . . \n", render.subsequent_row(0)
+    assert_equal "B . . . . \n", render.subsequent_row(1)
+    assert_equal "C . . . . \n", render.subsequent_row(2)
+    assert_equal "D . . . . \n", render.subsequent_row(3)
+  end
+
+  def test_subsequent_renders_sunken_ships
+    board = Board.new(4)
+    render = Render.new
+    sub = Ship.new("Sub", 2)
+
+    board.place(sub, "A1", true)
+    # ^ places sub in A1 horizontally -- A1 and A2
+    board.cells[:A1].fire_upon
+    board.cells[:A2].fire_upon
+
+    render.render(board)
+
+    assert_equal "A X X . . \n", render.subsequent_row(0)
+    assert_equal "B . . . . \n", render.subsequent_row(1)
+    assert_equal "C . . . . \n", render.subsequent_row(2)
+    assert_equal "D . . . . \n", render.subsequent_row(3)
+  end
+
+  def test_subsequent_renders_misses
+    board = Board.new(4)
+    render = Render.new
+    sub = Ship.new("Sub", 2)
+
+    board.place(sub, "A1", true)
+    # ^ places sub in A1 horizontally -- A1 and A2
+    board.cells[:A4].fire_upon # miss
+    board.cells[:C2].fire_upon # miss
+
+    render.render(board, true)
+
+    assert_equal "A S S . M \n", render.subsequent_row(0)
+    assert_equal "B . . . . \n", render.subsequent_row(1)
+    assert_equal "C . M . . \n", render.subsequent_row(2)
+    assert_equal "D . . . . \n", render.subsequent_row(3)
+  end
+
   def test_entire_reveal
     board = Board.new(5)
     render = Render.new

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -15,7 +15,7 @@ class RenderTest < Minitest::Test
 
     render.render(board)
 
-    assert_equal render.first_row(board), "  1 2 3 4 5 6 7 8 9 10 \n"
+    assert_equal "  1 2 3 4 5 6 7 8 9 10 \n", render.first_row
   end
 
   def test_first_row_shows_1_thru_other_board_size
@@ -24,7 +24,19 @@ class RenderTest < Minitest::Test
 
     render.render(board)
 
-    assert_equal render.first_row(board), "  1 2 3 4 \n"
+    assert_equal "  1 2 3 4 \n", render.first_row
+  end
+
+  def test_subsequent_row_renders
+    board = Board.new(4)
+    render = Render.new
+
+    render.render(board)
+
+    assert_equal "A . . . . \n", render.subsequent_row(0)
+    assert_equal "B . . . . \n", render.subsequent_row(1)
+    assert_equal "C . . . . \n", render.subsequent_row(2)
+    assert_equal "D . . . . \n", render.subsequent_row(3)
   end
 
 end

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -27,13 +27,29 @@ class RenderTest < Minitest::Test
     assert_equal "  1 2 3 4 \n", render.first_row
   end
 
-  def test_subsequent_row_renders
+  def test_subsequent_row_renders_initial_board
     board = Board.new(4)
     render = Render.new
 
     render.render(board)
 
     assert_equal "A . . . . \n", render.subsequent_row(0)
+    assert_equal "B . . . . \n", render.subsequent_row(1)
+    assert_equal "C . . . . \n", render.subsequent_row(2)
+    assert_equal "D . . . . \n", render.subsequent_row(3)
+  end
+
+  def test_subsequent_row_renders_ships_if_reveal
+    board = Board.new(4)
+    render = Render.new
+    sub = Ship.new("Sub", 2)
+
+    board.place(sub, "A1", true)
+    # ^ places sub in A1 horizontally -- A1 and A2
+
+    render.render(board, true)
+
+    assert_equal "A S S . . \n", render.subsequent_row(0)
     assert_equal "B . . . . \n", render.subsequent_row(1)
     assert_equal "C . . . . \n", render.subsequent_row(2)
     assert_equal "D . . . . \n", render.subsequent_row(3)

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -43,16 +43,52 @@ class RenderTest < Minitest::Test
     board = Board.new(4)
     render = Render.new
     sub = Ship.new("Sub", 2)
+    cruiser = Ship.new("Cruiser", 3)
 
     board.place(sub, "A1", true)
     # ^ places sub in A1 horizontally -- A1 and A2
+    board.place(cruiser, "A4", false)
+    # ^ places cruiser in A1 vertically -- A4 thru D4
 
     render.render(board, true)
 
-    assert_equal "A S S . . \n", render.subsequent_row(0)
+    assert_equal "A S S . S \n", render.subsequent_row(0)
+    assert_equal "B . . . S \n", render.subsequent_row(1)
+    assert_equal "C . . . S \n", render.subsequent_row(2)
+    assert_equal "D . . . . \n", render.subsequent_row(3)
+  end
+
+  def test_subsequent_row_doesnt_render_ships_if_reveal_is_false
+    board = Board.new(4)
+    render = Render.new
+    sub = Ship.new("Sub", 2)
+    cruiser = Ship.new("Cruiser", 3)
+
+    board.place(sub, "A1", true)
+    # ^ places sub in A1 horizontally -- A1 and A2
+    board.place(cruiser, "A4", false)
+    # ^ places cruiser in A1 vertically -- A4 thru D4
+
+    render.render(board) # inherent false for reveal
+
+    assert_equal "A . . . . \n", render.subsequent_row(0)
     assert_equal "B . . . . \n", render.subsequent_row(1)
     assert_equal "C . . . . \n", render.subsequent_row(2)
     assert_equal "D . . . . \n", render.subsequent_row(3)
+  end
+
+  def test_entire_reveal
+    board = Board.new(5)
+    render = Render.new
+
+    expected = "  1 2 3 4 5 \n"
+    expected += "A . . . . . \n"
+    expected += "B . . . . . \n"
+    expected += "C . . . . . \n"
+    expected += "D . . . . . \n"
+    expected += "E . . . . . \n"
+
+    assert_equal expected, render.render(board)
   end
 
 end

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -4,16 +4,9 @@ require './lib/render'
 
 class RenderTest < Minitest::Test
   def test_it_exists
-    board = Board.new
-    render = Render.new(board)
+    render = Render.new
 
     assert_instance_of Render, render
   end
 
-  def test_it_has_a_board
-    board = Board.new
-    render = Render.new(board)
-
-    assert_equal board, render.board
-  end
 end

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -9,4 +9,22 @@ class RenderTest < Minitest::Test
     assert_instance_of Render, render
   end
 
+  def test_first_row_shows_1_thru_default_board_size
+    board = Board.new
+    render = Render.new
+
+    render.render(board)
+
+    assert_equal render.first_row(board), "  1 2 3 4 5 6 7 8 9 10 \n"
+  end
+
+  def test_first_row_shows_1_thru_other_board_size
+    board = Board.new(4)
+    render = Render.new
+
+    render.render(board)
+
+    assert_equal render.first_row(board), "  1 2 3 4 \n"
+  end
+
 end


### PR DESCRIPTION
This branch/PR adds the Render and RenderTest classes.
- The Render class' `render(board)` method displays the entire board (headings and cell statuses). An optional input of true will reveal un-hit ships.
- Fixed off-by-1 error for length of ships in the Board's `place` method