### PR TITLE
Render tests fix

### DIFF
--- a/lib/render.rb
+++ b/lib/render.rb
@@ -18,7 +18,7 @@ class Render
   def names
     first_name_length = @boards[0].name.length
     board_size = @boards[0].size
-    board_render_width = 7 + 2 * board_size
+    board_render_width = 7 + 3 * board_size
     padding = (board_render_width - first_name_length) / 2
     padding = [padding, 0].max
     if @boards.size == 1
@@ -31,24 +31,26 @@ class Render
   def first_row
     size = @boards[0].size
     if @boards.size == 1
-        first_row_return = " " * 8
+        first_row_return = " " * 9
     else
-        first_row_return = " "
+        first_row_return = "  "
     end
 
     #OUR BOARD
     ('1'..size.to_s).each do |number|
       first_row_return += " " + number
+      first_row_return += " " if number.to_i < 9
     end
 
     #THEIR BOARD
     if @boards.size > 1
         first_row_return += " " * 3
         first_row_return += " " if @boards[1].size < 10
-        first_row_return += "|"
-        first_row_return += " " * 5
+        first_row_return += " |"
+        first_row_return += " " * 6
         ('1'..size.to_s).each do |number|
           first_row_return += " " + number
+          first_row_return += " " if number.to_i < 9
         end
     end
 
@@ -66,7 +68,7 @@ class Render
     @boards[0].size.times do |i|
       number = (i + 1).to_s
       cell = (letter + number).to_sym
-      row_render += " " + @boards[0][cell].render(@reveal == :one || @reveal == :all)
+      row_render += "  " + @boards[0][cell].render(@reveal == :one || @reveal == :all)
     end
 
     #THEIR BOARD
@@ -78,7 +80,7 @@ class Render
         @boards[1].size.times do |i|
           number = (i + 1).to_s
           cell = (letter + number).to_sym
-          row_render += " " + @boards[1][cell].render(@reveal == :two || @reveal == :all)
+          row_render += "  " + @boards[1][cell].render(@reveal == :two || @reveal == :all)
         end
     end
 

--- a/lib/render.rb
+++ b/lib/render.rb
@@ -3,7 +3,6 @@ require './lib/board'
 class Render
 
   def render(*boards, reveal)
-    # TO DO: ^ tests are very unhappy -- probably have to put reveal first
     @boards = boards
     @reveal = reveal
     render_return = names

--- a/lib/render.rb
+++ b/lib/render.rb
@@ -16,11 +16,16 @@ class Render
   end
 
   def names
-      if @boards.size == 1
-          return (" " * 12) + @boards[0].name + "\n"
-      else
-          return (" " * 5) + @boards[0].name + (" " * 8) + "|" + (" " * 9) + @boards[1].name + "\n"
-      end
+    first_name_length = @boards[0].name.length
+    board_size = @boards[0].size
+    board_render_width = 7 + 2 * board_size
+    padding = (board_render_width - first_name_length) / 2
+    padding = [padding, 0].max
+    if @boards.size == 1
+      return (" " * (5 + padding)) + @boards[0].name + "\n"
+    else
+      return (" " * padding) + @boards[0].name + (" " * padding) + (" " * padding) + @boards[1].name + "\n"
+    end
   end
 
   def first_row

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -16,7 +16,7 @@ class RenderTest < Minitest::Test
 
     render.render(board, false)
 
-    assert_equal "         1 2 3 4 5 6 7 8 9 10 \n", render.first_row
+    assert_equal "          1  2  3  4  5  6  7  8  9 10 \n", render.first_row
   end
 
   def test_first_row_shows_1_thru_other_board_size
@@ -25,7 +25,7 @@ class RenderTest < Minitest::Test
 
     render.render(board, false)
 
-    assert_equal "         1 2 3 4 \n", render.first_row
+    assert_equal "          1  2  3  4  \n", render.first_row
   end
 
   def test_subsequent_row_renders_initial_board
@@ -34,10 +34,10 @@ class RenderTest < Minitest::Test
 
     render.render(board, false)
 
-    assert_equal "       A . . . . \n", render.subsequent_row(0)
-    assert_equal "       B . . . . \n", render.subsequent_row(1)
-    assert_equal "       C . . . . \n", render.subsequent_row(2)
-    assert_equal "       D . . . . \n", render.subsequent_row(3)
+    assert_equal "       A  .  .  .  . \n", render.subsequent_row(0)
+    assert_equal "       B  .  .  .  . \n", render.subsequent_row(1)
+    assert_equal "       C  .  .  .  . \n", render.subsequent_row(2)
+    assert_equal "       D  .  .  .  . \n", render.subsequent_row(3)
   end
 
   def test_subsequent_row_renders_ships_if_reveal
@@ -53,10 +53,10 @@ class RenderTest < Minitest::Test
 
     render.render(board, :one)
 
-    assert_equal "       A S S . S \n", render.subsequent_row(0)
-    assert_equal "       B . . . S \n", render.subsequent_row(1)
-    assert_equal "       C . . . S \n", render.subsequent_row(2)
-    assert_equal "       D . . . . \n", render.subsequent_row(3)
+    assert_equal "       A  S  S  .  S \n", render.subsequent_row(0)
+    assert_equal "       B  .  .  .  S \n", render.subsequent_row(1)
+    assert_equal "       C  .  .  .  S \n", render.subsequent_row(2)
+    assert_equal "       D  .  .  .  . \n", render.subsequent_row(3)
   end
 
   def test_subsequent_row_doesnt_render_ships_if_reveal_is_false
@@ -72,10 +72,10 @@ class RenderTest < Minitest::Test
 
     render.render(board, false) # inherent false for reveal
 
-    assert_equal "       A . . . . \n", render.subsequent_row(0)
-    assert_equal "       B . . . . \n", render.subsequent_row(1)
-    assert_equal "       C . . . . \n", render.subsequent_row(2)
-    assert_equal "       D . . . . \n", render.subsequent_row(3)
+    assert_equal "       A  .  .  .  . \n", render.subsequent_row(0)
+    assert_equal "       B  .  .  .  . \n", render.subsequent_row(1)
+    assert_equal "       C  .  .  .  . \n", render.subsequent_row(2)
+    assert_equal "       D  .  .  .  . \n", render.subsequent_row(3)
   end
 
   def test_subsequent_renders_hit_ships
@@ -89,10 +89,10 @@ class RenderTest < Minitest::Test
 
     render.render(board, :one)
 
-    assert_equal "       A H S . . \n", render.subsequent_row(0)
-    assert_equal "       B . . . . \n", render.subsequent_row(1)
-    assert_equal "       C . . . . \n", render.subsequent_row(2)
-    assert_equal "       D . . . . \n", render.subsequent_row(3)
+    assert_equal "       A  H  S  .  . \n", render.subsequent_row(0)
+    assert_equal "       B  .  .  .  . \n", render.subsequent_row(1)
+    assert_equal "       C  .  .  .  . \n", render.subsequent_row(2)
+    assert_equal "       D  .  .  .  . \n", render.subsequent_row(3)
   end
 
   def test_subsequent_renders_sunken_ships
@@ -107,10 +107,10 @@ class RenderTest < Minitest::Test
 
     render.render(board, false)
 
-    assert_equal "       A X X . . \n", render.subsequent_row(0)
-    assert_equal "       B . . . . \n", render.subsequent_row(1)
-    assert_equal "       C . . . . \n", render.subsequent_row(2)
-    assert_equal "       D . . . . \n", render.subsequent_row(3)
+    assert_equal "       A  X  X  .  . \n", render.subsequent_row(0)
+    assert_equal "       B  .  .  .  . \n", render.subsequent_row(1)
+    assert_equal "       C  .  .  .  . \n", render.subsequent_row(2)
+    assert_equal "       D  .  .  .  . \n", render.subsequent_row(3)
   end
 
   def test_subsequent_renders_misses
@@ -125,10 +125,10 @@ class RenderTest < Minitest::Test
 
     render.render(board, :one)
 
-    assert_equal "       A S S . M \n", render.subsequent_row(0)
-    assert_equal "       B . . . . \n", render.subsequent_row(1)
-    assert_equal "       C . M . . \n", render.subsequent_row(2)
-    assert_equal "       D . . . . \n", render.subsequent_row(3)
+    assert_equal "       A  S  S  .  M \n", render.subsequent_row(0)
+    assert_equal "       B  .  .  .  . \n", render.subsequent_row(1)
+    assert_equal "       C  .  M  .  . \n", render.subsequent_row(2)
+    assert_equal "       D  .  .  .  . \n", render.subsequent_row(3)
   end
 
   def test_entire_reveal
@@ -136,12 +136,12 @@ class RenderTest < Minitest::Test
     render = Render.new
 
     expected = "            Board 1\n"
-    expected += "         1 2 3 4 5 \n"
-    expected += "       A . . . . . \n"
-    expected += "       B . . . . . \n"
-    expected += "       C . . . . . \n"
-    expected += "       D . . . . . \n"
-    expected += "       E . . . . . \n"
+    expected += "          1  2  3  4  5  \n"
+    expected += "       A  .  .  .  .  . \n"
+    expected += "       B  .  .  .  .  . \n"
+    expected += "       C  .  .  .  .  . \n"
+    expected += "       D  .  .  .  .  . \n"
+    expected += "       E  .  .  .  .  . \n"
 
     assert_equal expected, render.render(board, false)
   end

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -51,7 +51,7 @@ class RenderTest < Minitest::Test
     board.place(cruiser, "A4", false)
     # ^ places cruiser in A1 vertically -- A4 thru D4
 
-    render.render(board, true)
+    render.render(board, :one)
 
     assert_equal "       A S S . S \n", render.subsequent_row(0)
     assert_equal "       B . . . S \n", render.subsequent_row(1)
@@ -87,7 +87,7 @@ class RenderTest < Minitest::Test
     # ^ places sub in A1 horizontally -- A1 and A2
     board.cells[:A1].fire_upon
 
-    render.render(board, true)
+    render.render(board, :one)
 
     assert_equal "       A H S . . \n", render.subsequent_row(0)
     assert_equal "       B . . . . \n", render.subsequent_row(1)
@@ -123,7 +123,7 @@ class RenderTest < Minitest::Test
     board.cells[:A4].fire_upon # miss
     board.cells[:C2].fire_upon # miss
 
-    render.render(board, true)
+    render.render(board, :one)
 
     assert_equal "       A S S . M \n", render.subsequent_row(0)
     assert_equal "       B . . . . \n", render.subsequent_row(1)

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -11,12 +11,12 @@ class RenderTest < Minitest::Test
   end
 
   def test_first_row_shows_1_thru_default_board_size
-    board = Board.new("Board 1", 4)
+    board = Board.new("Board 1")
     render = Render.new
 
     render.render(board, false)
 
-    assert_equal "  1 2 3 4 5 6 7 8 9 10 \n", render.first_row
+    assert_equal "         1 2 3 4 5 6 7 8 9 10 \n", render.first_row
   end
 
   def test_first_row_shows_1_thru_other_board_size
@@ -25,7 +25,7 @@ class RenderTest < Minitest::Test
 
     render.render(board, false)
 
-    assert_equal "  1 2 3 4 \n", render.first_row
+    assert_equal "         1 2 3 4 \n", render.first_row
   end
 
   def test_subsequent_row_renders_initial_board
@@ -34,10 +34,10 @@ class RenderTest < Minitest::Test
 
     render.render(board, false)
 
-    assert_equal "A . . . . \n", render.subsequent_row(0)
-    assert_equal "B . . . . \n", render.subsequent_row(1)
-    assert_equal "C . . . . \n", render.subsequent_row(2)
-    assert_equal "D . . . . \n", render.subsequent_row(3)
+    assert_equal "       A . . . . \n", render.subsequent_row(0)
+    assert_equal "       B . . . . \n", render.subsequent_row(1)
+    assert_equal "       C . . . . \n", render.subsequent_row(2)
+    assert_equal "       D . . . . \n", render.subsequent_row(3)
   end
 
   def test_subsequent_row_renders_ships_if_reveal
@@ -53,10 +53,10 @@ class RenderTest < Minitest::Test
 
     render.render(board, true)
 
-    assert_equal "A S S . S \n", render.subsequent_row(0)
-    assert_equal "B . . . S \n", render.subsequent_row(1)
-    assert_equal "C . . . S \n", render.subsequent_row(2)
-    assert_equal "D . . . . \n", render.subsequent_row(3)
+    assert_equal "       A S S . S \n", render.subsequent_row(0)
+    assert_equal "       B . . . S \n", render.subsequent_row(1)
+    assert_equal "       C . . . S \n", render.subsequent_row(2)
+    assert_equal "       D . . . . \n", render.subsequent_row(3)
   end
 
   def test_subsequent_row_doesnt_render_ships_if_reveal_is_false
@@ -72,10 +72,10 @@ class RenderTest < Minitest::Test
 
     render.render(board, false) # inherent false for reveal
 
-    assert_equal "A . . . . \n", render.subsequent_row(0)
-    assert_equal "B . . . . \n", render.subsequent_row(1)
-    assert_equal "C . . . . \n", render.subsequent_row(2)
-    assert_equal "D . . . . \n", render.subsequent_row(3)
+    assert_equal "       A . . . . \n", render.subsequent_row(0)
+    assert_equal "       B . . . . \n", render.subsequent_row(1)
+    assert_equal "       C . . . . \n", render.subsequent_row(2)
+    assert_equal "       D . . . . \n", render.subsequent_row(3)
   end
 
   def test_subsequent_renders_hit_ships
@@ -89,10 +89,10 @@ class RenderTest < Minitest::Test
 
     render.render(board, true)
 
-    assert_equal "A H S . . \n", render.subsequent_row(0)
-    assert_equal "B . . . . \n", render.subsequent_row(1)
-    assert_equal "C . . . . \n", render.subsequent_row(2)
-    assert_equal "D . . . . \n", render.subsequent_row(3)
+    assert_equal "       A H S . . \n", render.subsequent_row(0)
+    assert_equal "       B . . . . \n", render.subsequent_row(1)
+    assert_equal "       C . . . . \n", render.subsequent_row(2)
+    assert_equal "       D . . . . \n", render.subsequent_row(3)
   end
 
   def test_subsequent_renders_sunken_ships
@@ -107,10 +107,10 @@ class RenderTest < Minitest::Test
 
     render.render(board, false)
 
-    assert_equal "A X X . . \n", render.subsequent_row(0)
-    assert_equal "B . . . . \n", render.subsequent_row(1)
-    assert_equal "C . . . . \n", render.subsequent_row(2)
-    assert_equal "D . . . . \n", render.subsequent_row(3)
+    assert_equal "       A X X . . \n", render.subsequent_row(0)
+    assert_equal "       B . . . . \n", render.subsequent_row(1)
+    assert_equal "       C . . . . \n", render.subsequent_row(2)
+    assert_equal "       D . . . . \n", render.subsequent_row(3)
   end
 
   def test_subsequent_renders_misses
@@ -125,22 +125,23 @@ class RenderTest < Minitest::Test
 
     render.render(board, true)
 
-    assert_equal "A S S . M \n", render.subsequent_row(0)
-    assert_equal "B . . . . \n", render.subsequent_row(1)
-    assert_equal "C . M . . \n", render.subsequent_row(2)
-    assert_equal "D . . . . \n", render.subsequent_row(3)
+    assert_equal "       A S S . M \n", render.subsequent_row(0)
+    assert_equal "       B . . . . \n", render.subsequent_row(1)
+    assert_equal "       C . M . . \n", render.subsequent_row(2)
+    assert_equal "       D . . . . \n", render.subsequent_row(3)
   end
 
   def test_entire_reveal
     board = Board.new("Board 1", 5)
     render = Render.new
 
-    expected = "  1 2 3 4 5 \n"
-    expected += "A . . . . . \n"
-    expected += "B . . . . . \n"
-    expected += "C . . . . . \n"
-    expected += "D . . . . . \n"
-    expected += "E . . . . . \n"
+    expected = "            Board 1\n"
+    expected += "         1 2 3 4 5 \n"
+    expected += "       A . . . . . \n"
+    expected += "       B . . . . . \n"
+    expected += "       C . . . . . \n"
+    expected += "       D . . . . . \n"
+    expected += "       E . . . . . \n"
 
     assert_equal expected, render.render(board, false)
   end


### PR DESCRIPTION
@Myrdden This PR/branch...
 - Fixes 9 Render tests that had been failing since we added more boards & padding (yay!)
 - Adds spacing between cells so that headings for boards > 10 display correctly
 - Fixes name padding (adjusts to board size)